### PR TITLE
Interpolation removed #211

### DIFF
--- a/bin/conpot
+++ b/bin/conpot
@@ -68,7 +68,7 @@ def logo():
 
 
 def on_unhandled_greenlet_exception(dead_greenlet):
-    logger.error('Stopping because {0} died: {1}'.format(dead_greenlet, dead_greenlet.exception))
+    logger.error('Stopping because %s died: %s', dead_greenlet, dead_greenlet.exception)
     sys.exit(1)
 
 
@@ -107,7 +107,7 @@ def drop_privileges(uid_name='nobody', gid_name='nogroup'):
     new_uid_name = pwd.getpwuid(os.getuid())[0]
     new_gid_name = grp.getgrgid(os.getgid())[0]
 
-    logger.info("Privileges dropped, running as {0}/{1}.".format(new_uid_name, new_gid_name))
+    logger.info('Privileges dropped, running as %s/%s.', new_uid_name, new_gid_name)
 
 
 def validate_template(xml_file, xsd_file):
@@ -116,7 +116,7 @@ def validate_template(xml_file, xsd_file):
     xml = etree.parse(xml_file)
     xsd.validate(xml)
     if xsd.error_log:
-        logger.error('Error parsing XML template: {0}'.format(xsd.error_log))
+        logger.error('Error parsing XML template: %s', xsd.error_log)
         sys.exit(1)
 
 
@@ -158,7 +158,7 @@ def main():
     config = ConfigParser()
     if not os.path.isfile(args.config):
         args.config = os.path.join(package_directory, 'conpot.cfg')
-        logger.info('No conpot.cfg found in current directory, using default configuration: {0}'.format(args.config))
+        logger.info('No conpot.cfg found in current directory, using default configuration: %s', args.config)
     config.read(args.config)
 
     # No template specified
@@ -211,16 +211,16 @@ def main():
     elif os.path.isfile(os.path.join(package_directory, 'templates', args.template, 'template.xml')):
         root_template_directory = os.path.join(package_directory, 'templates', args.template)
     else:
-            logger.error('Template not found: {0}'.format(args.template))
+            logger.error('Template not found: %s', args.template)
             sys.exit(1)
 
     # Check if the configuration file exists..
     if not os.path.isfile(args.config):
-        logger.error('Config not found: {0}'.format(args.config))
+        logger.error('Config not found: %s', args.config)
         sys.exit(1)
 
-    logger.info('Starting Conpot using template: {0}'.format(root_template_directory))
-    logger.info('Starting Conpot using configuration found in: {0}'.format(args.config))
+    logger.info('Starting Conpot using template: %s', root_template_directory)
+    logger.info('Starting Conpot using configuration found in: %s', args.config)
 
     servers = list()
 
@@ -265,11 +265,11 @@ def main():
                         greenlet = gevent.spawn(server.start, host, port)
                         greenlet.link_exception(on_unhandled_greenlet_exception)
                         servers.append(server)
-                        logger.info('Found and enabled {0} protocol.'.format(protocol))
+                        logger.info('Found and enabled %s protocol.', protocol)
                 else:
-                    logger.info('{0} available but disabled by configuration.'.format(protocol_name))
+                    logger.info('%s available but disabled by configuration.', protocol_name)
             else:
-                logger.debug('No {0} template found. Service will remain unconfigured/stopped.'.format(protocol_name))
+                logger.debug('No %s template found. Service will remain unconfigured/stopped.', protocol_name)
 
         log_worker = LogWorker(config, dom_base, session_manager, public_ip)
         greenlet = gevent.spawn(log_worker.start)

--- a/conpot/core/attack_session.py
+++ b/conpot/core/attack_session.py
@@ -28,7 +28,7 @@ class AttackSession(object):
     def __init__(self, protocol, source_ip, source_port, databus, log_queue):
         self.log_queue = log_queue
         self.id = uuid.uuid4()
-        logger.info('New {0} session from {1} ({2})'.format(protocol, source_ip, self.id))
+        logger.info('New %s session from %s (%s)', protocol, source_ip, self.id)
         self.protocol = protocol
         self.source_ip = source_ip
         self.source_port = source_port

--- a/conpot/core/databus.py
+++ b/conpot/core/databus.py
@@ -40,7 +40,7 @@ class Databus(object):
     # functions could be used if a profile wants to simulate a sensor, or the function
     # could interface with a real sensor
     def get_value(self, key):
-        logger.debug('DataBus: Get value from key: [{0}]'.format(key))
+        logger.debug('DataBus: Get value from key: [%s]', key)
         assert key in self._data
         item = self._data[key]
         if getattr(item, "get_value", None):
@@ -54,7 +54,7 @@ class Databus(object):
             return item
 
     def set_value(self, key, value):
-        logger.debug('DataBus: Storing key: [{0}] value: [{1}]'.format(key, value))
+        logger.debug('DataBus: Storing key: [%s] value: [%s]', key, value)
         self._data[key] = value
         # notify observers
         if key in self._observer_map:
@@ -73,7 +73,7 @@ class Databus(object):
 
     def initialize(self, config_file):
         self._reset()
-        logger.debug('Initializing databus using {0}.'.format(config_file))
+        logger.debug('Initializing databus using %s.', config_file)
         dom = etree.parse(config_file)
         entries = dom.xpath('//core/databus/key_value_mappings/*')
         for entry in entries:
@@ -81,7 +81,7 @@ class Databus(object):
             value = entry.xpath('./value/text()')[0].strip()
             value_type = str(entry.xpath('./value/@type')[0])
             assert key not in self._data
-            logging.debug('Initializing {0} with {1} as a {2}.'.format(key, value, value_type))
+            logging.debug('Initializing %s with %s as a %s.', key, value, value_type)
             if value_type == 'value':
                 self.set_value(key, eval(value))
             elif value_type == 'function':

--- a/conpot/core/loggers/log_worker.py
+++ b/conpot/core/loggers/log_worker.py
@@ -110,7 +110,7 @@ class LogWorker(object):
             sec_now = time.mktime(datetime.utcnow().timetuple())
             if (sec_now - (sec_session_start + sec_last_event)) >= session_timeout:
                 # TODO: We need to close sockets in this case
-                logger.info("Session timed out: {0}".format(session.id))
+                logger.info('Session timed out: %s', session.id)
                 session.set_ended()
                 sessions.remove(session)
 

--- a/conpot/core/loggers/mysql_log.py
+++ b/conpot/core/loggers/mysql_log.py
@@ -94,7 +94,7 @@ class MySQLlogger(object):
                 logger.error('Logging failed. Database connection not available.')
                 return False
             else:
-                logger.debug("Logging failed: Database connection lost. Retrying ({0} tries left)...".format(retry))
+                logger.debug('Logging failed: Database connection lost. Retrying (%s tries left)...', retry)
                 retry -= 1
                 gevent.sleep(float(0.5))
                 return self.log(event, retry)

--- a/conpot/core/loggers/taxii_log.py
+++ b/conpot/core/loggers/taxii_log.py
@@ -52,7 +52,7 @@ class TaxiiLogger(object):
         response_message = libtaxii.get_message_from_http_response(response, '0')
 
         if response_message.status_type != libtaxii.messages.ST_SUCCESS:
-            logger.error('Error while transmitting message to TAXII server: {0}'.format(response_message.message))
+            logger.error('Error while transmitting message to TAXII server: %s', response_message.message)
             return False
         else:
             return True

--- a/conpot/emulators/proxy.py
+++ b/conpot/emulators/proxy.py
@@ -56,14 +56,16 @@ class Proxy(object):
         else:
             server = StreamServer(connection, self.handle)
         self.port = server.server_port
-        logger.info('{0} proxy server started, listening on {1}, proxy for: ({2}, {3}) using {4} decoder.'
-                    .format(self.name, connection, self.proxy_host, self.proxy_port, self.decoder))
+        logger.info(
+            '%s proxy server started, listening on %s, proxy for: (%s, %s) using %s decoder.',
+            self.name, connection, self.proxy_host, self.proxy_port, self.decoder)
         return server
 
     def handle(self, sock, address):
         session = conpot_core.get_session(self.proxy_id, address[0], address[1])
-        logger.info('New connection from {0}:{1} on {2} proxy. ({3})'.format(address[0], address[1],
-                                                                             self.proxy_id, session.id))
+        logger.info(
+            'New connection from %s:%s on %s proxy. (%s)',
+            address[0], address[1], self.proxy_id, session.id)
         proxy_socket = socket()
 
         if self.keyfile and self.certfile:
@@ -72,8 +74,7 @@ class Proxy(object):
         try:
             proxy_socket.connect((self.proxy_host, self.proxy_port))
         except _socket.error as ex:
-            logger.error('Error while connecting to proxied service at ({0}, {1}): {2}'
-                         .format(self.proxy_host, self.proxy_port, ex))
+            logger.error('Error while connecting to proxied service at (%s, %s): %s', self.proxy_host, self.proxy_port, ex)
             self._close([proxy_socket, sock])
             return
 
@@ -96,13 +97,15 @@ class Proxy(object):
                 if len(data) is 0:
                     self._close([proxy_socket, sock])
                     if s is proxy_socket:
-                        logging.warning('Closing proxied socket while receiving ({0}, {1}): {2}.'
-                                        .format(self.proxy_host, self.proxy_port, socket_close_reason))
+                        logging.warning(
+                            'Closing proxied socket while receiving (%s, %s): %s.', 
+                            self.proxy_host, self.proxy_port, socket_close_reason)
                         sockets = []
                         break
                     elif s is sock:
-                        logging.warning('Closing connection to remote while receiving from remote ({0}, {1}): {2}'
-                                        .format(socket_close_reason, address[0], address[1]))
+                        logging.warning(
+                            'Closing connection to remote while receiving from remote (%s, %s): %s',
+                            socket_close_reason, address[0], address[1])
                         sockets = []
                         break
                     else:
@@ -120,7 +123,7 @@ class Proxy(object):
                         destination = 'proxied socket'
                     else:
                         destination = 'remote connection'
-                    logger.warning('Error while sending data to {0}: {1}.'.format(destination, str(socket_err)))
+                    logger.warning('Error while sending data to %s: %s.', destination, str(socket_err))
                     sockets = []
                     break
 
@@ -131,22 +134,22 @@ class Proxy(object):
     def handle_in_data(self, data, sock, session):
         hex_data = data.encode('hex_codec')
         session.add_event({'raw_request': hex_data, 'raw_response': ''})
-        logger.debug('Received {0} bytes from outside to proxied service: {1}'.format(len(data), hex_data))
+        logger.debug('Received %s bytes from outside to proxied service: %s', len(data), hex_data)
         if self.decoder:
             # TODO: data could be chunked, proxy needs to handle this
             decoded = self.decoder.decode_in(data)
-            logger.debug('Decoded request: {0}'.format(decoded))
+            logger.debug('Decoded request: %s', decoded)
             session.add_event({'request': decoded, 'raw_response': ''})
         sock.send(data)
 
     def handle_out_data(self, data, sock, session):
         hex_data = data.encode('hex_codec')
         session.add_event({'raw_request': '', 'raw_response': hex_data})
-        logger.debug('Received {0} bytes from proxied service: {1}'.format(len(data), hex_data))
+        logger.debug('Received %s bytes from proxied service: %s', len(data), hex_data)
         if self.decoder:
             # TODO: data could be chunked, proxy needs to handle this
             decoded = self.decoder.decode_out(data)
-            logger.debug('Decoded response: {0}'.format(decoded))
+            logger.debug('Decoded response: %s', decoded)
             session.add_event({'request': '', 'raw_response': decoded})
         sock.send(data)
 

--- a/conpot/protocols/http/command_responder.py
+++ b/conpot/protocols/http/command_responder.py
@@ -48,10 +48,10 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
                     'dst_port': self.server.server_port,
                     'data': {0: {'request': '{0} {1}: {2}'.format(version, request_type, request)}}}
 
-        logger.info('{0} {1} request from {2}: {3}. {4}'.format(version, request_type, addr, request, session.id))
+        logger.info('%s %s request from %s: %s. %s', version, request_type, addr, request, session.id)
 
         if response:
-            logger.info('{0} response to {1}: {2}. {3}'.format(version, addr, response, session.id))
+            logger.info('%s response to %s: %s. %s', version, addr, response, session.id)
             log_dict['data'][0]['response'] = '{0} response: {1}'.format(version, response)
             session.add_event({'request': str(request), 'response': str(response)})
         else:
@@ -230,7 +230,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
                     payload = f.read()
 
             except IOError, e:
-                logger.error('{0}'.format(e))
+                logger.error('%s', e)
                 payload = ''
 
             # there might be template data that can be substituted within the
@@ -399,7 +399,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
 
             except IOError as e:
                 if not os.path.isdir(os.path.join(docpath, 'htdocs', relrqfilename)):
-                    logger.error('Failed to get template content: {0}'.format(e))
+                    logger.error('Failed to get template content: %s', e)
                 payload = ''
 
             # there might be template data that can be substituted within the
@@ -1043,7 +1043,7 @@ class SubHTTPServer(ThreadedHTTPServer):
                 _ = float(x)
             except ValueError:
                 # first value is invalid, ignore the whole setting.
-                logger.error("Invalid tarpit value: '{0}'. Assuming no latency.".format(value))
+                logger.error("Invalid tarpit value: '%s'. Assuming no latency.", value)
                 return '0;0'
 
             try:

--- a/conpot/protocols/http/web_server.py
+++ b/conpot/protocols/http/web_server.py
@@ -32,7 +32,7 @@ class HTTPServer(object):
         self.cmd_responder = None
 
     def start(self, host, port):
-        logger.info('HTTP server started on: {0}'.format((host, port)))
+        logger.info('HTTP server started on: %s', (host, port))
         self.cmd_responder = CommandResponder(host, port, self.template, os.path.join(self.template_directory, 'http'))
         self.cmd_responder.httpd.allow_reuse_address = True
         self.server_port = self.cmd_responder.server_port

--- a/conpot/protocols/kamstrup/management_protocol/kamstrup_management_server.py
+++ b/conpot/protocols/kamstrup/management_protocol/kamstrup_management_server.py
@@ -35,7 +35,7 @@ class KamstrupManagementServer(object):
 
     def handle(self, sock, address):
         session = conpot_core.get_session('kamstrup_management_protocol', address[0], address[1])
-        logger.info('New connection from {0}:{1}. ({2})'.format(address[0], address[1], session.id))
+        logger.info('New connection from %s:%s. (%s)', address[0], address[1], session.id)
         session.add_event({'type': 'NEW_CONNECTION'})
 
         try:
@@ -45,14 +45,14 @@ class KamstrupManagementServer(object):
             while True:
                 request = sock.recv(1024)
                 if not request:
-                    logger.info('Client disconnected. ({0})'.format(session.id))
+                    logger.info('Client disconnected. (%s)', session.id)
                     session.add_event({'type': 'CONNECTION_LOST'})
                     break
 
                 logdata = {'request': request}
                 response = self.command_responder.respond(request)
                 logdata['response'] = response
-                logger.debug('Kamstrup management traffic from {0}: {1} ({2})'.format(address[0], logdata, session.id))
+                logger.debug('Kamstrup management traffic from %s: %s (%s)', address[0], logdata, session.id)
                 session.add_event(logdata)
                 gevent.sleep(0.25)  # TODO measure delay and/or RTT
 
@@ -62,7 +62,7 @@ class KamstrupManagementServer(object):
                 sock.send(response)
 
         except socket.timeout:
-            logger.debug('Socket timeout, remote: {0}. ({1})'.format(address[0], session.id))
+            logger.debug('Socket timeout, remote: %s. (%s)', address[0], session.id)
             session.add_event({'type': 'CONNECTION_LOST'})
 
         sock.close()
@@ -70,5 +70,5 @@ class KamstrupManagementServer(object):
     def start(self, host, port):
         connection = (host, port)
         server = StreamServer(connection, self.handle)
-        logger.info('Kamstrup management protocol server started on: {0}'.format(connection))
+        logger.info('Kamstrup management protocol server started on: %s', connection)
         server.start()

--- a/conpot/protocols/kamstrup/meter_protocol/command_responder.py
+++ b/conpot/protocols/kamstrup/meter_protocol/command_responder.py
@@ -46,8 +46,9 @@ class CommandResponder(object):
 
     def respond(self, request):
         if request.communication_address != self.communication_address:
-            logger.debug('Request received with wrong communication address, got {0} but expected {1}.'.format(request.communication_address,
-                                                                                                               self.communication_address))
+            logger.debug(
+                'Request received with wrong communication address, got %s but expected %s.',
+                request.communication_address, self.communication_address)
             return None
         elif isinstance(request, messages.KamstrupRequestGetRegisters):
             response = messages.KamstrupResponseRegister(self.communication_address)

--- a/conpot/protocols/kamstrup/meter_protocol/decoder_382.py
+++ b/conpot/protocols/kamstrup/meter_protocol/decoder_382.py
@@ -75,7 +75,7 @@ class Decoder382(object):
         for d in data:
             d = ord(d)
             if not self.in_parsing and d != kamstrup_constants.REQUEST_MAGIC:
-                logger.debug('No kamstrup_meter request magic received, got: {0}'.format(d.encode('hex-codec')))
+                logger.debug('No kamstrup_meter request magic received, got: %s', d.encode('hex-codec'))
             else:
                 self.in_parsing = True
 
@@ -113,7 +113,7 @@ class Decoder382(object):
         for d in data:
             d = ord(d)
             if not self.out_parsing and d != kamstrup_constants.RESPONSE_MAGIC:
-                logger.debug('Expected response magic but got got: {0}'.format(d.encode('hex-codec')))
+                logger.debug('Expected response magic but got got: %s', d.encode('hex-codec'))
             else:
                 self.out_parsing = True
 

--- a/conpot/protocols/kamstrup/meter_protocol/kamstrup_server.py
+++ b/conpot/protocols/kamstrup/meter_protocol/kamstrup_server.py
@@ -52,7 +52,7 @@ class KamstrupServer(object):
 
     def handle(self, sock, address):
         session = conpot_core.get_session('kamstrup_protocol', address[0], address[1])
-        logger.info('New connection from {0}:{1}. ({2})'.format(address[0], address[1], session.id))
+        logger.info('New connection from %s:%s. (%s)', address[0], address[1], session.id)
         session.add_event({'type': 'NEW_CONNECTION'})
 
         server_active = True
@@ -63,7 +63,7 @@ class KamstrupServer(object):
                 raw_request = sock.recv(1024)
 
                 if not raw_request:
-                    logger.info('Client disconnected. ({0})'.format(session.id))
+                    logger.info('Client disconnected. (%s)', session.id)
                     session.add_event({'type': 'CONNECTION_LOST'})
                     break
 
@@ -83,7 +83,7 @@ class KamstrupServer(object):
                         if response:
                             serialized_response = response.serialize()
                             logdata['response'] = binascii.hexlify(serialized_response)
-                            logger.debug('Kamstrup traffic from {0}: {1} ({2})'.format(address[0], logdata, session.id))
+                            logger.debug('Kamstrup traffic from %s: %s (%s)', address[0], logdata, session.id)
                             sock.send(serialized_response)
                             session.add_event(logdata)
                         else:
@@ -91,7 +91,7 @@ class KamstrupServer(object):
                             break
 
         except socket.timeout:
-            logger.debug('Socket timeout, remote: {0}. ({1})'.format(address[0], session.id))
+            logger.debug('Socket timeout, remote: %s. (%s)', address[0], session.id)
             session.add_event({'type': 'CONNECTION_LOST'})
 
         sock.close()
@@ -99,7 +99,7 @@ class KamstrupServer(object):
     def start(self, host, port):
         connection = (host, port)
         server = StreamServer(connection, self.handle)
-        logger.info('Kamstrup protocol server started on: {0}'.format(connection))
+        logger.info('Kamstrup protocol server started on: %s', connection)
         server.start()
 
 

--- a/conpot/protocols/kamstrup/meter_protocol/messages.py
+++ b/conpot/protocols/kamstrup/meter_protocol/messages.py
@@ -37,7 +37,7 @@ class KamstrupRequestBase(KamstrupProtocolBase):
         super(KamstrupRequestBase, self).__init__(communication_address)
         self.command = command
         self.message_bytes = message_bytes
-        logger.debug('Request package created with bytes: {0}'.format(self.message_bytes))
+        logger.debug('Request package created with bytes: %s', self.message_bytes)
 
     def __str__(self):
         return 'Comm address: {0}, Command: {1}, Message: {2}'.format(hex(self.communication_address),
@@ -50,7 +50,7 @@ class KamstrupRequestUnknown(KamstrupRequestBase):
     def __init__(self, communication_address, command_byte, message_bytes):
         super(KamstrupRequestUnknown, self).__init__(communication_address,
                                                      command_byte, message_bytes)
-        logger.warning('Unknown Kamstrup request: {0}'.format(self))
+        logger.warning('Unknown Kamstrup request: %s', self)
 
 
 class KamstrupRequestGetRegisters(KamstrupRequestBase):
@@ -62,7 +62,7 @@ class KamstrupRequestGetRegisters(KamstrupRequestBase):
                                                           KamstrupRequestGetRegisters.command_byte, message_bytes)
         self.registers = []
         self._parse_register_bytes()
-        logger.debug('Request for registers: {0}'.format(str(self.registers).strip('[]')))
+        logger.debug('Request for registers: %s', str(self.registers).strip('[]'))
 
     def _parse_register_bytes(self):
         register_count = self.message_bytes[0]

--- a/conpot/protocols/modbus/modbus_server.py
+++ b/conpot/protocols/modbus/modbus_server.py
@@ -39,16 +39,16 @@ class ModbusServer(modbus.Server):
         for s in slaves:
             slave_id = int(s.attrib['id'])
             slave = self.add_slave(slave_id)
-            logger.debug('Added slave with id {0}.'.format(slave_id))
+            logger.debug('Added slave with id %s.', slave_id)
             for b in s.xpath('./blocks/*'):
                 name = b.attrib['name']
                 request_type = eval('mdef.' + b.xpath('./type/text()')[0])
                 start_addr = int(b.xpath('./starting_address/text()')[0])
                 size = int(b.xpath('./size/text()')[0])
                 slave.add_block(name, request_type, start_addr, size)
-                logger.debug('Added block {0} to slave {1}. (type={2}, start={3}, size={4})'.format(
-                    name, slave_id, request_type, start_addr, size
-                ))
+                logger.debug(
+                    'Added block %s to slave %s. (type=%s, start=%s, size=%s)',
+                    name, slave_id, request_type, start_addr, size)
 
         logger.info('Conpot modbus initialized')
 
@@ -58,18 +58,18 @@ class ModbusServer(modbus.Server):
         session = conpot_core.get_session('modbus', address[0], address[1])
 
         self.start_time = time.time()
-        logger.info('New connection from {0}:{1}. ({2})'.format(address[0], address[1], session.id))
+        logger.info('New connection from %s:%s. (%s)', address[0], address[1], session.id)
         session.add_event({'type': 'NEW_CONNECTION'})
 
         try:
             while True:
                 request = sock.recv(7)
                 if not request:
-                    logger.info('Client disconnected. ({0})'.format(session.id))
+                    logger.info('Client disconnected. (%s)', session.id)
                     session.add_event({'type': 'CONNECTION_LOST'})
                     break
                 if request.strip().lower() == 'quit.':
-                    logger.info('Client quit. ({0})'.format(session.id))
+                    logger.info('Client quit. (%s)', session.id)
                     session.add_event({'type': 'CONNECTION_QUIT'})
                     break
                 tr_id, pr_id, length = struct.unpack(">HHH", request[:6])
@@ -83,16 +83,16 @@ class ModbusServer(modbus.Server):
                 logdata['request'] = request.encode('hex')
                 session.add_event(logdata)
 
-                logger.debug('Modbus traffic from {0}: {1} ({2})'.format(address[0], logdata, session.id))
+                logger.debug('Modbus traffic from %s: %s (%s)', address[0], logdata, session.id)
 
                 if response:
                     sock.sendall(response)
         except socket.timeout:
-            logger.debug('Socket timeout, remote: {0}. ({1})'.format(address[0], session.id))
+            logger.debug('Socket timeout, remote: %s. (%s)', address[0], session.id)
             session.add_event({'type': 'CONNECTION_LOST'})
 
     def start(self, host, port):
         connection = (host, port)
         server = StreamServer(connection, self.handle)
-        logger.info('Modbus server started on: {0}'.format(connection))
+        logger.info('Modbus server started on: %s', connection)
         server.start()

--- a/conpot/protocols/modbus/slave.py
+++ b/conpot/protocols/modbus/slave.py
@@ -93,7 +93,7 @@ class MBSlave(Slave):
                 raise Exception("No response for function %d" % self.function_code)
 
             except ModbusError as e:
-                logger.error('Exception caught: {0}. (A proper response will be sent to the peer)'.format(e))
+                logger.error('Exception caught: %s. (A proper response will be sent to the peer)', e)
                 return struct.pack(">BB", self.function_code + 128, e.get_exception_code())
 
     def add_block(self, block_name, block_type, starting_address, size):

--- a/conpot/protocols/snmp/build_pysnmp_mib_wrapper.py
+++ b/conpot/protocols/snmp/build_pysnmp_mib_wrapper.py
@@ -38,7 +38,7 @@ def mib2pysnmp(mib_file):
     :param mib_file: Path to the MIB file.
     :return: A string representation of the compiled MIB file (string).
     """
-    logger.debug('Compiling mib file: {0}'.format(mib_file))
+    logger.debug('Compiling mib file: %s', mib_file)
     try:
         proc = subprocess.Popen([BUILD_SCRIPT, mib_file], stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
@@ -56,7 +56,7 @@ def mib2pysnmp(mib_file):
                         .format(BUILD_SCRIPT, stderr, stdout))
         raise Exception(stderr)
     else:
-        logger.debug('Successfully compiled MIB file: {0}'.format(mib_file))
+        logger.debug('Successfully compiled MIB file: %s', mib_file)
         return stdout
 
 

--- a/conpot/protocols/snmp/command_responder.py
+++ b/conpot/protocols/snmp/command_responder.py
@@ -132,10 +132,10 @@ class CommandResponder(object):
             x = MibScalarInstance(s.name, instance, s.syntax.clone(value))
             self.snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder.exportSymbols(mibname, x)
 
-            logger.debug('Registered: OID {0} Instance {1} ASN.1 ({2} @ {3}) value {4} dynrsp.'.format(s.name, instance, s.label, mibname, value))
+            logger.debug('Registered: OID %s Instance %s ASN.1 (%s @ %s) value %s dynrsp.', s.name, instance, s.label, mibname, value)
 
         else:
-            logger.debug('Skipped: OID for symbol {0} not found in MIB {1}'.format(symbolname, mibname))
+            logger.debug('Skipped: OID for symbol %s not found in MIB %s', symbolname, mibname)
 
     def _get_mibSymbol(self, mibname, symbolname):
         modules = self.snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder.mibSymbols

--- a/conpot/protocols/snmp/conpot_cmdrsp.py
+++ b/conpot/protocols/snmp/conpot_cmdrsp.py
@@ -39,12 +39,12 @@ class conpot_extension(object):
                     'data_type': 'snmp',
                     'data': {0: {'request': 'SNMPv{0} {1}: {2} {3}'.format(version, msg_type, req_oid, req_val)}}}
 
-        logger.info('SNMPv{0} {1} request from {2}: {3} {4}'.format(version, msg_type, addr, req_oid, req_val))
+        logger.info('SNMPv%s %s request from %s: %s %s', version, msg_type, addr, req_oid, req_val)
 
         if res_varBinds:
             res_oid = ".".join(map(str, res_varBinds[0][0]))
             res_val = res_varBinds[0][1]
-            logger.info('SNMPv{0} response to {1}: {2} {3}'.format(version, addr, res_oid, res_val))
+            logger.info('SNMPv%s response to %s: %s %s', version, addr, res_oid, res_val)
             log_dict['data'][0]['response'] = 'SNMPv{0} response: {1} {2}'.format(version, res_oid, res_val)
         # log here...
 
@@ -75,18 +75,13 @@ class conpot_extension(object):
 
         if int(threshold_individual) > 0:
             if int(state_individual) > int(threshold_individual):
-                logger.warning('SNMPv{0}: DoS threshold for {1} exceeded ({2}/{3}).'.format(cmd,
-                                                                                            addr,
-                                                                                            state_individual,
-                                                                                            threshold_individual))
+                logger.warning('SNMPv%s: DoS threshold for %s exceeded (%s/%s).', cmd, addr, state_individual, threshold_individual)
                 # DoS threshold exceeded.
                 return True
 
         if int(threshold_overall) > 0:
             if int(state_overall) > int(threshold_overall):
-                logger.warning('SNMPv{0}: DDoS threshold exceeded ({1}/{2}).'.format(cmd,
-                                                                                     state_individual,
-                                                                                     threshold_overall))
+                logger.warning('SNMPv%s: DDoS threshold exceeded (%s/%s).', cmd, state_individual, threshold_overall)
                 # DDoS threshold exceeded
                 return True
 

--- a/conpot/protocols/snmp/snmp_server.py
+++ b/conpot/protocols/snmp/snmp_server.py
@@ -134,7 +134,7 @@ class SNMPServer(object):
             try:
                 _ = float(x)
             except ValueError:
-                logger.error("Invalid tarpit value: '{0}'. Assuming no latency.".format(value))
+                logger.error("Invalid tarpit value: '%s'. Assuming no latency.", value)
                 # first value is invalid, ignore the whole setting.
                 return '0;0'
 
@@ -161,7 +161,7 @@ class SNMPServer(object):
             try:
                 _ = int(x)
             except ValueError:
-                logger.error("Invalid evasion threshold: '{0}'. Assuming no DoS evasion.".format(value))
+                logger.error("Invalid evasion threshold: '%s'. Assuming no DoS evasion.", value)
                 # first value is invalid, ignore the whole setting.
                 return '0;0'
 
@@ -181,7 +181,7 @@ class SNMPServer(object):
         self.xml_general_config(self.dom)
         self.xml_mib_config(self.dom, self.compiled_mibs, self.raw_mibs)
 
-        logger.info('SNMP server started on: {0}'.format((host, self.get_port())))
+        logger.info('SNMP server started on: %s', (host, self.get_port()))
         self.cmd_responder.serve_forever()
 
     def stop(self):

--- a/conpot/utils/ext_ip.py
+++ b/conpot/utils/ext_ip.py
@@ -49,7 +49,7 @@ def _fetch_data(urls):
             else:
                 raise ConnectionError
         except (Timeout, ConnectionError) as e:
-            logger.warning('Could not fetch public ip from {0}'.format(url))
+            logger.warning('Could not fetch public ip from %s', url)
     return None
 
 
@@ -58,9 +58,9 @@ def get_ext_ip(config=None, urls=None):
         urls = json.loads(config.get('fetch_public_ip', 'urls'))
     public_ip = _fetch_data(urls)
     if public_ip:
-        logger.info('Fetched {0} as external ip.'.format(public_ip))
+        logger.info('Fetched %s as external ip.', public_ip)
     else:
-        logger.warning('Could not fetch public ip: {0}'.format(public_ip))
+        logger.warning('Could not fetch public ip: %s', public_ip)
     return public_ip
 
 


### PR DESCRIPTION
Removing Interpollation from logging scripts to reduce overhead. 
Blacklisting s7_server.py in automated script as we have to fix some bugs there.

Remaining..
conpot/protocols/s7comm/s7_server.py:58
conpot/protocols/s7comm/s7_server.py:67
conpot/protocols/s7comm/s7_server.py:111
conpot/protocols/s7comm/s7_server.py:172
conpot/protocols/s7comm/s7_server.py:177
conpot/protocols/s7comm/s7_server.py:182