### PR TITLE
Improved modbus UID handling

### DIFF
--- a/conpot/protocols/modbus/modbus.xsd
+++ b/conpot/protocols/modbus/modbus.xsd
@@ -12,6 +12,8 @@
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
+                <xs:element type="xs:string" name="mode"/>
+                <xs:element type="xs:byte" name="delay"/>
                 <xs:element name="slaves">
                     <xs:complexType>
                         <xs:sequence>
@@ -53,7 +55,7 @@
                                             </xs:complexType>
                                         </xs:element>
                                     </xs:sequence>
-                                    <xs:attribute type="xs:byte" name="id" use="required"/>
+                                    <xs:attribute type="xs:short" name="id" use="required"/>
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>

--- a/conpot/protocols/modbus/modbus_server.py
+++ b/conpot/protocols/modbus/modbus_server.py
@@ -36,7 +36,7 @@ class ModbusServer(modbus.Server):
             self, databank if databank else modbus.Databank())
 
         # retrieve mode of connection and turnaround delay from the template
-        self._setup(template)
+        self._get_mode_and_delay(template)
 
         # not sure how this class remember slave configuration across
         # instance creation, i guess there are some
@@ -44,11 +44,10 @@ class ModbusServer(modbus.Server):
         self.remove_all_slaves()
         self._configure_slaves(template)
 
-    def _setup(self, template):
+    def _get_mode_and_delay(self, template):
         dom = etree.parse(template)
         self.mode = dom.xpath('//modbus/mode/text()')[0].lower()
-        if (self.mode != 'tcp' and
-                self.mode != 'serial'):
+        if self.mode not in ['tcp', 'serial']:
             logger.error('Conpot modbus initialization failed due to incorrect'
                          ' settings. Check the modbus template file')
             sys.exit(3)
@@ -79,7 +78,7 @@ class ModbusServer(modbus.Server):
                         name, slave_id, request_type, start_addr, size)
 
             logger.info('Conpot modbus initialized')
-        except (Exception, DuplicatedKeyError) as e:
+        except (Exception) as e:
             logger.info(e)
 
     def handle(self, sock, address):

--- a/conpot/protocols/modbus/modbus_server.py
+++ b/conpot/protocols/modbus/modbus_server.py
@@ -1,7 +1,10 @@
+# modified by Sooky Peter <xsooky00@stud.fit.vutbr.cz>
+# Brno University of Technology, Faculty of Information Technology
 import struct
 import socket
 import time
 import logging
+import sys
 
 from lxml import etree
 from gevent.server import StreamServer
@@ -11,6 +14,7 @@ from modbus_tk import modbus
 # Following imports are required for modbus template evaluation
 import modbus_tk.defines as mdef
 import random
+from modbus_tk.modbus import DuplicatedKeyError
 
 from conpot.protocols.modbus import slave_db
 import conpot.core as conpot_core
@@ -23,34 +27,60 @@ class ModbusServer(modbus.Server):
     def __init__(self, template, template_directory, args, timeout=5):
 
         self.timeout = timeout
+        self.delay = None
+        self.mode = None
         databank = slave_db.SlaveBase(template)
 
         # Constructor: initializes the server settings
-        modbus.Server.__init__(self, databank if databank else modbus.Databank())
+        modbus.Server.__init__(
+            self, databank if databank else modbus.Databank())
 
-        # not sure how this class remember slave configuration across instance creation, i guess there are some
+        # retrieve mode of connection and turnaround delay from the template
+        self._setup(template)
+
+        # not sure how this class remember slave configuration across
+        # instance creation, i guess there are some
         # well hidden away class variables somewhere.
         self.remove_all_slaves()
         self._configure_slaves(template)
 
+    def _setup(self, template):
+        dom = etree.parse(template)
+        self.mode = dom.xpath('//modbus/mode/text()')[0].lower()
+        if (self.mode != 'tcp' and
+                self.mode != 'serial'):
+            logger.error('Conpot modbus initialization failed due to incorrect'
+                         ' settings. Check the modbus template file')
+            sys.exit(3)
+        try:
+            self.delay = int(dom.xpath('//modbus/delay/text()')[0])
+        except ValueError:
+            logger.error('Conpot modbus initialization failed due to incorrect'
+                         ' settings. Check the modbus template file')
+            sys.exit(3)
+
     def _configure_slaves(self, template):
         dom = etree.parse(template)
         slaves = dom.xpath('//modbus/slaves/*')
-        for s in slaves:
-            slave_id = int(s.attrib['id'])
-            slave = self.add_slave(slave_id)
-            logger.debug('Added slave with id %s.', slave_id)
-            for b in s.xpath('./blocks/*'):
-                name = b.attrib['name']
-                request_type = eval('mdef.' + b.xpath('./type/text()')[0])
-                start_addr = int(b.xpath('./starting_address/text()')[0])
-                size = int(b.xpath('./size/text()')[0])
-                slave.add_block(name, request_type, start_addr, size)
-                logger.debug(
-                    'Added block %s to slave %s. (type=%s, start=%s, size=%s)',
-                    name, slave_id, request_type, start_addr, size)
+        try:
+            for s in slaves:
+                slave_id = int(s.attrib['id'])
+                slave = self.add_slave(slave_id)
+                logger.debug('Added slave with id %s.', slave_id)
+                for b in s.xpath('./blocks/*'):
+                    name = b.attrib['name']
+                    request_type = eval('mdef.' + b.xpath('./type/text()')[0])
+                    start_addr = int(b.xpath('./starting_address/text()')[0])
+                    size = int(b.xpath('./size/text()')[0])
+                    slave.add_block(name, request_type, start_addr, size)
+                    logger.debug(
+                        'Added block %s to slave %s. '
+                        '(type=%s, start=%s, size=%s)',
+                        name, slave_id, request_type, start_addr, size)
 
-        logger.info('Conpot modbus initialized')
+            logger.info('Conpot modbus initialized')
+        except (Exception, DuplicatedKeyError) as e:
+            logger.info(e)
 
     def handle(self, sock, address):
         sock.settimeout(self.timeout)
@@ -58,7 +88,9 @@ class ModbusServer(modbus.Server):
         session = conpot_core.get_session('modbus', address[0], address[1])
 
         self.start_time = time.time()
-        logger.info('New connection from %s:%s. (%s)', address[0], address[1], session.id)
+        logger.info(
+            'New connection from %s:%s. (%s)',
+            address[0], address[1], session.id)
         session.add_event({'type': 'NEW_CONNECTION'})
 
         try:
@@ -78,17 +110,44 @@ class ModbusServer(modbus.Server):
                     request += new_byte
                 query = modbus_tcp.TcpQuery()
 
-                # logdata is a dictionary containing request, slave_id, function_code and response
-                response, logdata = self._databank.handle_request(query, request)
+                # logdata is a dictionary containing request, slave_id,
+                # function_code and response
+                response, logdata = self._databank.handle_request(
+                    query, request, self.mode)
                 logdata['request'] = request.encode('hex')
                 session.add_event(logdata)
 
-                logger.debug('Modbus traffic from %s: %s (%s)', address[0], logdata, session.id)
+                logger.debug(
+                    'Modbus traffic from %s: %s (%s)',
+                    address[0], logdata, session.id)
 
                 if response:
                     sock.sendall(response)
+                    logger.info('Modbus response sent to %s', address[0])
+                else:
+                    # MB serial connection addressing UID=0
+                    if (self.mode == 'serial' and logdata['slave_id'] == 0):
+                        # delay is in milliseconds
+                        time.sleep(self.delay / 1000)
+                        logger.debug(
+                            'Modbus server\'s turnaround delay expired.')
+                        logger.info('Connection terminated with client %s.',
+                                    address[0])
+                        session.add_event({'type': 'CONNECTION_TERMINATED'})
+                        sock.shutdown(socket.SHUT_RDWR)
+                        sock.close()
+                        break
+                    # Invalid addressing
+                    else:
+                        logger.info('Client ignored due to invalid addressing.'
+                                    ' (%s)', session.id)
+                        session.add_event({'type': 'CONNECTION_TERMINATED'})
+                        sock.shutdown(socket.SHUT_RDWR)
+                        sock.close()
+                        break
         except socket.timeout:
-            logger.debug('Socket timeout, remote: %s. (%s)', address[0], session.id)
+            logger.debug(
+                'Socket timeout, remote: %s. (%s)', address[0], session.id)
             session.add_event({'type': 'CONNECTION_LOST'})
 
     def start(self, host, port):
@@ -96,3 +155,4 @@ class ModbusServer(modbus.Server):
         server = StreamServer(connection, self.handle)
         logger.info('Modbus server started on: %s', connection)
         server.start()
+

--- a/conpot/protocols/modbus/slave_db.py
+++ b/conpot/protocols/modbus/slave_db.py
@@ -1,13 +1,20 @@
+# modified by Sooky Peter <xsooky00@stud.fit.vutbr.cz>
+# Brno University of Technology, Faculty of Information Technology
 import struct
 from lxml import etree
 
-from modbus_tk.modbus import Databank, DuplicatedKeyError, MissingKeyError
+from modbus_tk.modbus import Databank, DuplicatedKeyError, MissingKeyError, \
+                             ModbusInvalidRequestError
 from modbus_tk import defines
 
 from conpot.protocols.modbus.slave import MBSlave
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class SlaveBase(Databank):
+
     """
     Database keeping track of the slaves.
     """
@@ -20,17 +27,18 @@ class SlaveBase(Databank):
         """
         Add a new slave with the given id
         """
-        if (slave_id <= 0) or (slave_id > 255):
+        if (slave_id < 0) or (slave_id > 255):
             raise Exception("Invalid slave id %d" % slave_id)
-        if not slave_id in self._slaves:
+        if slave_id not in self._slaves:
             self._slaves[slave_id] = MBSlave(slave_id, self.dom)
             return self._slaves[slave_id]
         else:
             raise DuplicatedKeyError("Slave %d already exists" % slave_id)
 
-    def handle_request(self, query, request):
+    def handle_request(self, query, request, mode):
         """
-        Handles a request. Return value is a tuple where element 0 is the response object and element 1 is a dictionary
+        Handles a request. Return value is a tuple where element 0
+        is the response object and element 1 is a dictionary
         of items to log.
         """
         request_pdu = None
@@ -46,31 +54,52 @@ class SlaveBase(Databank):
             slave_id, request_pdu = query.parse_request(request)
             if len(request_pdu) > 0:
                 (func_code, ) = struct.unpack(">B", request_pdu[0])
-            # 43 is Device Information
-            if func_code == 43:
-                # except will throw MissingKeyError
-                slave = self.get_slave(slave_id)
-                response_pdu = slave.handle_request(request_pdu)
-                # make the full response
-                response = query.build_response(response_pdu)
-            # get the slave and let him execute the action
-            elif slave_id == 0:
-                # broadcast
-                for key in self._slaves:
-                    response_pdu = self._slaves[key].handle_request(request_pdu, broadcast=True)
+            if mode == 'tcp':
+                if slave_id == 0:
+                    slave = self.get_slave(slave_id)
+                    response_pdu = slave.handle_request(request_pdu)
                     response = query.build_response(response_pdu)
-            elif slave_id == 255:
-                r = struct.pack(">BB", func_code + 0x80, 0x0B)
-                response = query.build_response(r)
-            else:
-                slave = self.get_slave(slave_id)
-                response_pdu = slave.handle_request(request_pdu)
-                # make the full response
-                response = query.build_response(response_pdu)
+                elif slave_id == 255:
+                    # r = struct.pack(">BB", func_code + 0x80, 0x0B)
+                    # response = query.build_response(r)
+                    slave = self.get_slave(slave_id)
+                    response_pdu = slave.handle_request(request_pdu)
+                    response = query.build_response(response_pdu)
+                else:
+                    # return no response, and data necessary for logging
+                    return (None, {'request': request_pdu.encode('hex'),
+                                   'slave_id': slave_id,
+                                   'function_code': func_code,
+                                   'response': ''})
+            elif mode == 'serial':
+                if slave_id == 0:
+                    for key in self._slaves:
+                        response_pdu = self._slaves[key].handle_request(
+                            request_pdu, broadcast=True)
+                    # no response is sent
+                    return (None, {'request': request_pdu.encode('hex'),
+                                   'slave_id': slave_id,
+                                   'function_code': func_code,
+                                   'response': ''})
+                elif slave_id > 0 and slave_id <= 247:
+                    slave = self.get_slave(slave_id)
+                    response_pdu = slave.handle_request(request_pdu)
+                    # make the full response
+                    response = query.build_response(response_pdu)
+                else:
+                    # return no response, and data necessary for logging
+                    return (None, {'request': request_pdu.encode('hex'),
+                                   'slave_id': slave_id,
+                                   'function_code': func_code,
+                                   'response': ''})
         except (IOError, MissingKeyError) as e:
-            # If the request was not handled correctly, return a server error response
-            r = struct.pack(">BB", func_code + 0x80, defines.SLAVE_DEVICE_FAILURE)
+            # If the request was not handled correctly, return a server error
+            # response
+            r = struct.pack(
+                ">BB", func_code + 0x80, defines.SLAVE_DEVICE_FAILURE)
             response = query.build_response(r)
+        except (ModbusInvalidRequestError) as e:
+            logger.info(e)
 
         if slave:
             function_code = slave.function_code
@@ -79,3 +108,4 @@ class SlaveBase(Databank):
                            'slave_id': slave_id,
                            'function_code': function_code,
                            'response': response_pdu.encode('hex')})
+

--- a/conpot/templates/default/modbus/modbus.xml
+++ b/conpot/templates/default/modbus/modbus.xml
@@ -4,7 +4,49 @@
         <ProductCode>SIMATIC</ProductCode>
         <MajorMinorRevision>S7-200</MajorMinorRevision>
     </device_info>
+    <mode>serial</mode>
+    <delay>100</delay>
     <slaves>
+        <slave id="0">
+            <blocks>
+                <block name="memoryModbusSlave0BlockA">
+                    <!-- COILS/DISCRETE_OUTPUTS aka. binary output, power on/power off
+                         Here we map modbus addresses 1 to 127 to S7-200 PLC Addresses Q0.0 to Q15.7 -->
+                    <type>COILS</type>
+                    <starting_address>1</starting_address>
+                    <size>128</size>
+                    <content>memoryModbusSlave0BlockA</content>
+                </block>
+                <block name="memoryModbusSlave0BlockB">
+                    <!-- CONTACTS/DISCRETE_INPUTS aka. binary input.
+                         Map modbus addresses 10001-10032 to S7-200 PLC inputs starting from I0.0  -->
+                    <type>DISCRETE_INPUTS</type>
+                    <starting_address>10001</starting_address>
+                    <size>32</size>
+                    <content>memoryModbusSlave0BlockB</content>
+                </block>
+            </blocks>
+        </slave>
+        <slave id="255">
+            <blocks>
+                <block name="memoryModbusSlave255BlockA">
+                    <!-- COILS/DISCRETE_OUTPUTS aka. binary output, power on/power off
+                         Here we map modbus addresses 1 to 127 to S7-200 PLC Addresses Q0.0 to Q15.7 -->
+                    <type>COILS</type>
+                    <starting_address>1</starting_address>
+                    <size>128</size>
+                    <content>memoryModbusSlave255BlockA</content>
+                </block>
+                <block name="memoryModbusSlave255BlockB">
+                    <!-- CONTACTS/DISCRETE_INPUTS aka. binary input.
+                         Map modbus addresses 10001-10032 to S7-200 PLC inputs starting from I0.0  -->
+                    <type>DISCRETE_INPUTS</type>
+                    <starting_address>10001</starting_address>
+                    <size>32</size>
+                    <content>memoryModbusSlave255BlockB</content>
+                </block>
+            </blocks>
+        </slave>
         <slave id="1">
             <blocks>
                 <block name="memoryModbusSlave1BlockA">

--- a/conpot/templates/default/template.xml
+++ b/conpot/templates/default/template.xml
@@ -37,6 +37,18 @@
             <key name="sysServices">
                 <value type="value">"72"</value>
             </key>
+            <key name="memoryModbusSlave0BlockA">
+                <value type="value">[random.randint(0,1) for b in range(0,128)]</value>
+            </key>
+            <key name="memoryModbusSlave0BlockB">
+                <value type="value">[random.randint(0,1) for b in range(0,32)]</value>
+            </key>
+            <key name="memoryModbusSlave255BlockA">
+                <value type="value">[random.randint(0,1) for b in range(0,128)]</value>
+            </key>
+            <key name="memoryModbusSlave255BlockB">
+                <value type="value">[random.randint(0,1) for b in range(0,32)]</value>
+            </key>
             <key name="memoryModbusSlave1BlockA">
                 <value type="value">[random.randint(0,1) for b in range(0,128)]</value>
             </key>


### PR DESCRIPTION
Possible solution to issue #101 
Modified slave addressing according to the preset value of mode in the modbus.xml file. The mode values are either "serial" or "tcp". Added two slaves with UIDs 0 and 255 for Modbus/TCP to the template. Added turnaround delay for Master in case of broadcasting a request over MB serial line.