### PR TITLE
Catch Exception in snmp command responder

### DIFF
--- a/conpot/protocols/snmp/command_responder.py
+++ b/conpot/protocols/snmp/command_responder.py
@@ -26,7 +26,10 @@ class SNMPDispatcher(DatagramServer):
         self.recvCbFun = recvCbFun
 
     def handle(self, msg, address):
-        self.recvCbFun(self, self.transportDomain, address, msg)
+        try:
+            self.recvCbFun(self, self.transportDomain, address, msg)
+        except Exception as e:
+            logger.info("SNMP Exception: %s", e)
 
     def registerTransport(self, tDomain, transport):
         DatagramServer.__init__(self, transport, self.handle)


### PR DESCRIPTION
to avoid:

    to avoid:
    Traceback (most recent call last):
      File "/usr/local/lib/python2.7/dist-packages/gevent-1.0.1-py2.7-linux-i686.egg/gevent/greenlet.py", line 327, in run
        result = self._run(*self.args, **self.kwargs)
      File "/usr/local/lib/python2.7/dist-packages/Conpot-0.4.0-py2.7.egg/conpot/protocols/snmp/command_responder.py", line 29, in handle
        self.recvCbFun(self, self.transportDomain, address, msg)
      File "/usr/local/lib/python2.7/dist-packages/pysnmp/entity/engine.py", line 64, in __receiveMessageCbFun
        self, transportDomain, transportAddress, wholeMsg
      File "/usr/local/lib/python2.7/dist-packages/pysnmp/proto/rfc3412.py", line 416, in receiveMessage
        stateReference
      File "/usr/local/lib/python2.7/dist-packages/pysnmp/entity/rfc3413/cmdrsp.py", line 146, in processPdu
        contextName, PDU, (self.__verifyAccess, acCtx)
      File "/usr/local/lib/python2.7/dist-packages/Conpot-0.4.0-py2.7.egg/conpot/protocols/snmp/conpot_cmdrsp.py", line 219, in handleMgmtOperation
        raise Exception('This class is not converted to new architecture')
    Exception: This class is not converted to new architecture

maybe optional, but I get also this:
<Greenlet at 0xb498520cL: <bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of <SNMPDispatcher at 0xb4ac6cccL fileno=12 address=0.0.0.0:161 handle=<bound method SNMPDispatcher.handle of f ...