### PR TITLE
Add git workflow into guidelines

### DIFF
--- a/docs/source/development/guidelines.rst
+++ b/docs/source/development/guidelines.rst
@@ -21,3 +21,84 @@ Copyright
 Environment
 -----------
 * PyCharm is recommended.
+
+Recommended git workflow
+------------------------
+
+For contributors
+~~~~~~~~~~~~~~~~
+
+1, For every feature, create new branch:
+
+::
+
+  git checkout -b feature_branch
+
+2, State what you do in commit message.
+
+When you create pull request and get review, it is recommended to edit your original commits.
+
+3a, If you want to change the last commit:
+
+::
+
+  (make some changes in files)
+  git add file1 file2
+  git commit --amend
+
+3b, If you want to change any of your previous commits:
+
+::
+
+  git rebase -i HEAD~3  (can be HEAD~4, depends which commit you want to change, or you can type hash of previous commit)
+
+change "pick" to "e":
+
+::
+
+  e e88a2f1 commit 1
+  pick bfd57e4 commit2
+
+and save.
+
+::
+
+  (make some changes in files)
+  git add file1 file2
+  git rebase --continue
+
+Warning:
+Do not use 'git commit' in rebase if you don't know what you are doing.
+
+4, Look at your changes, and git force push to your branch:
+
+::
+
+  git push -f feature_branch
+
+5, Comment in pull request to let us know about your new code.
+
+For maintainers
+~~~~~~~~~~~~~~~
+
+To avoid additional Merge commits, use cherry-pick:
+
+::
+
+  git checkout master
+  git remote add user https://github.com/user/conpot.git
+  git fetch user/feature_branch
+  (look at 'git log user/feature_branch')
+  git cherry-pick commit_hash
+  git push origin master
+  git remote rm user
+
+Comment on pull request that you added it to master, and close pull request.
+
+This approach is usefull for majority of pull requests (1-3 commits).
+
+If you expect conflicts (a lot of commits in feature branch with a lot of changes) you can use GitHub Merge button.
+
+Revert will be easier too.
+
+Conflicts should not happen, if feature branch is rebased on current master.


### PR DESCRIPTION
hi guys, check this out. I am open to discussion.

when cherry-pick, Author stays the same, but Committer is changed. ( git log -1 --pretty=full )
It looks like this on GitHub https://github.com/netsniff-ng/netsniff-ng/commits/master
https://github.com/CZ-NIC/kippo/commits/master
and like this on GitLab https://gitlab.labs.nic.cz/honeynet/kippo/commits/master

The main advantage is that git log is not:
Merge commit
normal commit
Merge commit
normal commit

From contributor point of view, main advantage is, that they will create couple of nice commits (not 25 of them per simple change)